### PR TITLE
Small changes in the current schema of the docker files. 

### DIFF
--- a/container-specs.md
+++ b/container-specs.md
@@ -6,17 +6,18 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 
 
 
-| Field                 | Description                                                                                                                | Example                                                  |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| base_image            | The original image where the software has been built | base_image: biodckr/biodocker |
-| software.version      | Version of the software and tool                     | software.version: 2015020     |
-| software              | Name of the software                                 | software: Comet               |
-| about.summary         | A short description of the software or tool.         | about.summary: Peptide identification|
-| about.home            | The original software website where  and examples.   | about.home: http://comet-ms.sourceforge.net/  |
-| about.documentation   | URL(s) containing information about software            | about.documentation: http://comet-ms.sourceforge.net/     |
-| about.license         | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | about.license: SPDX:Apache-2.0          |
-| about.license_file    | license path location in the container or url (according to license requirements |          |  
-| about.tags            | Tags about the software that enable to find and classify the software tool.| about.tags: proteomics, mass spectrometry, biocontainers       |
+| Field          | Description | Optional                                             | Example   |
+|----------------|------------ |------------------------------------------------------|-----------|
+| base_image            | The original image where the software has been built | **Mandatory** | base_image: biodckr/biodocker |
+| software.version      | Version of the software and tool                     | **Mandatory** | software.version: 2015020     |
+| software              | Name of the software                                 | **Mandatory** | software: Comet               |
+| about.summary         | A short description of the software or tool.         | **Mandatory** | about.summary: Peptide identification|
+| about.home            | The original software website where  and examples.   | **Mandatory** | about.home: http://comet-ms.sourceforge.net/  |
+| about.documentation   | URL(s) containing information about software         | _Optional_  | about.documentation: http://comet-ms.sourceforge.net/     |
+| about.license         | SPDX license specification. If not in the SPDX listspecify URL in license_file> | **Mandatory** | about.license: SPDX:Apache-2.0          |
+| about.license_file    | license path location in the container or url (according to license requirements | _Optional_ |         |  
+| about.tags            | Tags about the software that enable to find and classify the software tool.| _Optional_ | about.tags: proteomics, mass spectrometry, biocontainers       |
+| MANTAINER | The developer in charge of the container/software | **Mandatory** | MAINTAINER Yasset Perez-Riverol <yperez@ebi.ac.uk> | 
 
 
 ### Dockerfile example:

--- a/container-specs.md
+++ b/container-specs.md
@@ -7,16 +7,16 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 
 
 | Field                 | Description                                                                                                                | Example                                                  |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| base_image            | The original image where the software has been built                                                                         | base_image: biodckr/biodocker                            |
-| software_version      | Every BioContainer should contain the actual version of the software and tool                                               | software_version: 2015020                                |
-| software              | Name of the software                                                                                                         | software: Comet                                          |
-| description           | A short description of the software or tool.                                                                                 | description: Peptide identification search tool          |
-| home                  | The original software website where the user can find information about the tool the algorithms and examples.               | home: http://comet-ms.sourceforge.net/                |
-| documentation         | URL(s) containing information about how to use the software.                                                                 | documentation: http://comet-ms.sourceforge.net/              |
-| license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | license: SPDX:Apache-2.0          |
-| license_file          | license path location in the container or url (according to license requirements |          |  
-| tags                  | Tags about the software that enable to find and classify the software tool.                                                 | tags: proteomics, mass spectrometry, biocontainers       |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| base_image            | The original image where the software has been built | base_image: biodckr/biodocker |
+| software.version      | Version of the software and tool                     | software.version: 2015020     |
+| software              | Name of the software                                 | software: Comet               |
+| about.summary         | A short description of the software or tool.         | about.summary: Peptide identification|
+| about.home            | The original software website where  and examples.   | about.home: http://comet-ms.sourceforge.net/  |
+| about.documentation   | URL(s) containing information about software            | aobut.documentation: http://comet-ms.sourceforge.net/     |
+| about.license         | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | about.license: SPDX:Apache-2.0          |
+| about.license_file    | license path location in the container or url (according to license requirements |          |  
+| about.tags            | Tags about the software that enable to find and classify the software tool.| about.tags: proteomics, mass spectrometry, biocontainers       |
 
 
 ### Dockerfile example:
@@ -29,13 +29,13 @@ FROM biocontainers/biocontainers:latest
 LABEL base_image="biocontainers:latest"
 LABEL version="3"
 LABEL software="Comet"
-LABEL software_version="2016012"
-LABEL description="an open source tandem mass spectrometry sequence database search tool"
-LABEL home="http://comet-ms.sourceforge.net/"
-LABEL documentation="http://comet-ms.sourceforge.net/parameters/parameters_2016010/"
-LABEL license="SPDX:Apache-2.0"
-LABEL license_file="/usr/share/common-licenses/Apache-2.0"
-LABEL tags="Proteomics"
+LABEL software.version="2016012"
+LABEL about.summary="an open source tandem mass spectrometry sequence database search tool"
+LABEL about.home="http://comet-ms.sourceforge.net/"
+LABEL about.documentation="http://comet-ms.sourceforge.net/parameters/parameters_2016010/"
+LABEL about.license="SPDX:Apache-2.0"
+LABEL about.license_file="/usr/share/common-licenses/Apache-2.0"
+LABEL about.tags="Proteomics"
 
 # Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>

--- a/container-specs.md
+++ b/container-specs.md
@@ -13,7 +13,7 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 | software              | Name of the software                                 | software: Comet               |
 | about.summary         | A short description of the software or tool.         | about.summary: Peptide identification|
 | about.home            | The original software website where  and examples.   | about.home: http://comet-ms.sourceforge.net/  |
-| about.documentation   | URL(s) containing information about software            | aobut.documentation: http://comet-ms.sourceforge.net/     |
+| about.documentation   | URL(s) containing information about software            | about.documentation: http://comet-ms.sourceforge.net/     |
 | about.license         | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | about.license: SPDX:Apache-2.0          |
 | about.license_file    | license path location in the container or url (according to license requirements |          |  
 | about.tags            | Tags about the software that enable to find and classify the software tool.| about.tags: proteomics, mass spectrometry, biocontainers       |
@@ -54,5 +54,4 @@ ENV PATH /home/biodocker/bin/Comet:$PATH
 
 WORKDIR /data/
 
-CMD ["comet"]
 ~~~

--- a/container-specs.md
+++ b/container-specs.md
@@ -17,7 +17,8 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 | about.license         | SPDX license specification. If not in the SPDX listspecify URL in license_file> | **Mandatory** | about.license: SPDX:Apache-2.0          |
 | about.license_file    | license path location in the container or url (according to license requirements | _Optional_ |         |  
 | about.tags            | Tags about the software that enable to find and classify the software tool.| _Optional_ | about.tags: proteomics, mass spectrometry, biocontainers       |
-| MANTAINER | The developer in charge of the container/software | **Mandatory** | MAINTAINER Yasset Perez-Riverol <yperez@ebi.ac.uk> | 
+| MANTAINER | The developer in charge of the container/software | **Mandatory** | MAINTAINER Yasset Perez-Riverol <yperez@ebi.ac.uk> |
+|extra.identifier  | Extra identifiers are external idnetifers in other resources that will allow to pul metadata, an external information from other resources (e.g biotoolS). In order to be compatible with Docker specification the domain (database) of the identifiers should be specify in the name of the label. | _Optional_ | extra.identifier.biotools=abyss |  
 
 
 ### Dockerfile example:
@@ -37,6 +38,7 @@ LABEL about.documentation="http://comet-ms.sourceforge.net/parameters/parameters
 LABEL about.license="SPDX:Apache-2.0"
 LABEL about.license_file="/usr/share/common-licenses/Apache-2.0"
 LABEL about.tags="Proteomics"
+LABEL extra.identifiers.biotools=comet
 
 # Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>

--- a/container-specs.md
+++ b/container-specs.md
@@ -8,13 +8,13 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 
 | Field                 | Description                                                                                                                | Example                                                  |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| base-image            | The original image where the software has been built                                                                       | base image: biodckr/biodocker                            |
-| software-version      | Every BioContainer should contain the actual version of the software and tool                                               | software version: 2015020                                |
-| software              | Name of the software                                                                                                       | software: Comet                                          |
-| description           | A short description of the software or tool.                                                                               | description: Peptide identification search tool          |
+| base_image            | The original image where the software has been built                                                                         | base image: biodckr/biodocker                            |
+| software_version      | Every BioContainer should contain the actual version of the software and tool                                               | software version: 2015020                                |
+| software              | Name of the software                                                                                                         | software: Comet                                          |
+| description           | A short description of the software or tool.                                                                                 | description: Peptide identification search tool          |
 | home                  | The original software website where the user can find information about the tool the algorithms and examples.               | website: http://comet-ms.sourceforge.net/                |
-| documentation         | URL(s) containing information about how to use the software.                                                               | doc pages: http://comet-ms.sourceforge.net/              |
-| license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>                                                                                   | SPDX:Apache-2.0          |
+| documentation         | URL(s) containing information about how to use the software.                                                                 | doc pages: http://comet-ms.sourceforge.net/              |
+| license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | SPDX:Apache-2.0          |
 | license-file          | license path location in the container or url (according to license requirements |          |  
 | tags                  | Tags about the software that enable to find and classify the software tool.                                                 | tags: proteomics, mass spectrometry, biocontainers       |
 
@@ -26,15 +26,15 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 FROM biocontainers/biocontainers:latest
 
 # Metadata
-LABEL base-image="biocontainers:latest"
+LABEL base_image="biocontainers:latest"
 LABEL version="3"
 LABEL software="Comet"
-LABEL software-version="2016012"
+LABEL software_version="2016012"
 LABEL description="an open source tandem mass spectrometry sequence database search tool"
 LABEL home="http://comet-ms.sourceforge.net/"
 LABEL documentation="http://comet-ms.sourceforge.net/parameters/parameters_2016010/"
 LABEL license="SPDX:Apache-2.0"
-LABEL license-file="/usr/share/common-licenses/Apache-2.0"
+LABEL license_file="/usr/share/common-licenses/Apache-2.0"
 LABEL tags="Proteomics"
 
 # Maintainer

--- a/container-specs.md
+++ b/container-specs.md
@@ -8,14 +8,14 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 
 | Field                 | Description                                                                                                                | Example                                                  |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| base_image            | The original image where the software has been built                                                                       | base image: biodckr/biodocker                            |
-| software_version      | Every BioContainer should contain the actual version of the software and tool                                               | software version: 2015020                                |
+| base-image            | The original image where the software has been built                                                                       | base image: biodckr/biodocker                            |
+| software-version      | Every BioContainer should contain the actual version of the software and tool                                               | software version: 2015020                                |
 | software              | Name of the software                                                                                                       | software: Comet                                          |
 | description           | A short description of the software or tool.                                                                               | description: Peptide identification search tool          |
 | home                  | The original software website where the user can find information about the tool the algorithms and examples.               | website: http://comet-ms.sourceforge.net/                |
 | documentation         | URL(s) containing information about how to use the software.                                                               | doc pages: http://comet-ms.sourceforge.net/              |
 | license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>                                                                                   | SPDX:Apache-2.0          |
-| license_file          | license path location in the container or url (according to license requirements |          |  
+| license-file          | license path location in the container or url (according to license requirements |          |  
 | tags                  | Tags about the software that enable to find and classify the software tool.                                                 | tags: proteomics, mass spectrometry, biocontainers       |
 
 
@@ -26,15 +26,15 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 FROM biocontainers/biocontainers:latest
 
 # Metadata
-LABEL base.image="biocontainers:latest"
+LABEL base-image="biocontainers:latest"
 LABEL version="3"
 LABEL software="Comet"
-LABEL software_version="2016012"
+LABEL software-version="2016012"
 LABEL description="an open source tandem mass spectrometry sequence database search tool"
 LABEL home="http://comet-ms.sourceforge.net/"
 LABEL documentation="http://comet-ms.sourceforge.net/parameters/parameters_2016010/"
 LABEL license="SPDX:Apache-2.0"
-LABEL license_file="/usr/share/common-licenses/Apache-2.0"
+LABEL license-file="/usr/share/common-licenses/Apache-2.0"
 LABEL tags="Proteomics"
 
 # Maintainer

--- a/container-specs.md
+++ b/container-specs.md
@@ -8,15 +8,15 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 
 | Field                 | Description                                                                                                                | Example                                                  |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| base image            | The original image where the software has been built                                                                       | base image: biodckr/biodocker                            |
-| software version      | Every BioContainer should contain the actual version of the software and tool                                              | software version: 2015020                                |
+| base_image            | The original image where the software has been built                                                                       | base image: biodckr/biodocker                            |
+| software_version      | Every BioContainer should contain the actual version of the software and tool                                               | software version: 2015020                                |
 | software              | Name of the software                                                                                                       | software: Comet                                          |
 | description           | A short description of the software or tool.                                                                               | description: Peptide identification search tool          |
-| website               | The original software website where the user can find information about the tool the algorithms and examples.              | website: http://comet-ms.sourceforge.net/                |
+| home                  | The original software website where the user can find information about the tool the algorithms and examples.               | website: http://comet-ms.sourceforge.net/                |
 | documentation         | URL(s) containing information about how to use the software.                                                               | doc pages: http://comet-ms.sourceforge.net/              |
 | license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>                                                                                   | SPDX:Apache-2.0          |
 | license_file          | license path location in the container or url (according to license requirements |          |  
-| tags                  | Tags about the software that enable to find and classify the software tool.                                                | tags: proteomics, mass spectrometry, biocontainers       |
+| tags                  | Tags about the software that enable to find and classify the software tool.                                                 | tags: proteomics, mass spectrometry, biocontainers       |
 
 
 ### Dockerfile example:
@@ -29,9 +29,9 @@ FROM biocontainers/biocontainers:latest
 LABEL base.image="biocontainers:latest"
 LABEL version="3"
 LABEL software="Comet"
-LABEL software.version="2016012"
+LABEL software_version="2016012"
 LABEL description="an open source tandem mass spectrometry sequence database search tool"
-LABEL website="http://comet-ms.sourceforge.net/"
+LABEL home="http://comet-ms.sourceforge.net/"
 LABEL documentation="http://comet-ms.sourceforge.net/parameters/parameters_2016010/"
 LABEL license="SPDX:Apache-2.0"
 LABEL license_file="/usr/share/common-licenses/Apache-2.0"

--- a/container-specs.md
+++ b/container-specs.md
@@ -8,14 +8,14 @@ We explain here the containers metadata, their meaning and use in BioContainers:
 
 | Field                 | Description                                                                                                                | Example                                                  |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| base_image            | The original image where the software has been built                                                                         | base image: biodckr/biodocker                            |
-| software_version      | Every BioContainer should contain the actual version of the software and tool                                               | software version: 2015020                                |
+| base_image            | The original image where the software has been built                                                                         | base_image: biodckr/biodocker                            |
+| software_version      | Every BioContainer should contain the actual version of the software and tool                                               | software_version: 2015020                                |
 | software              | Name of the software                                                                                                         | software: Comet                                          |
 | description           | A short description of the software or tool.                                                                                 | description: Peptide identification search tool          |
-| home                  | The original software website where the user can find information about the tool the algorithms and examples.               | website: http://comet-ms.sourceforge.net/                |
-| documentation         | URL(s) containing information about how to use the software.                                                                 | doc pages: http://comet-ms.sourceforge.net/              |
-| license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | SPDX:Apache-2.0          |
-| license-file          | license path location in the container or url (according to license requirements |          |  
+| home                  | The original software website where the user can find information about the tool the algorithms and examples.               | home: http://comet-ms.sourceforge.net/                |
+| documentation         | URL(s) containing information about how to use the software.                                                                 | documentation: http://comet-ms.sourceforge.net/              |
+| license               | SPDX license specification. If not in the SPDX list, then set short description and specify URL in license_file>           | license: SPDX:Apache-2.0          |
+| license_file          | license path location in the container or url (according to license requirements |          |  
 | tags                  | Tags about the software that enable to find and classify the software tool.                                                 | tags: proteomics, mass spectrometry, biocontainers       |
 
 


### PR DESCRIPTION
Minor changes in the schema LABEL names to make them more consistent. Please @osallou @prvst @mr-c take a look at this PR. The basic idea here is to make standard the current names. We should consider a major redefinition of the schema for the future including the comments from @mr-c and other about been compatible with http://label-schema.org/rc1/ . I recommend to accept this PR first as small change to the schema and then move into a major changes. 

@mr-c I think is more important now that you check if the current entry-point for containers is fine for `cwl` and also the use of biodocker user `USER biodocker` is also fine. We also recommend the use of the working directory `WORKDIR /data/` please give us your feedback on that. 